### PR TITLE
change 90 to 60 days in faq

### DIFF
--- a/ExpressEntryCalculator.Web/Views/Home/Index.cshtml
+++ b/ExpressEntryCalculator.Web/Views/Home/Index.cshtml
@@ -548,7 +548,7 @@
                                 Get to the group of the highest-ranking candidates in the pool to apply for permanent residence and receive an invitation from the Canadian Government.<br/>
                                 Canadian Government send
                                 <a href="https://www.canada.ca/en/immigration-refugees-citizenship/services/immigrate-canada/express-entry/become-candidate/invitations-apply.html" target="_blank">invitations to apply</a> to the candidates with the highest scores in the pool. If Government invite you to apply,
-                                you will have 90 days to submit an online
+                                you will have 60 (before 90) days to submit an online
                                 <a href="https://www.canada.ca/en/immigration-refugees-citizenship/services/immigrate-canada/express-entry/apply-permanent-residence.html" target="_blank">application for permanent residence</a>.
                                 Canadian Government will process most complete applications that have all the supporting documents in six months or less.
                                 You can stay in the pool for up to 12 months as long as you meet the criteria for one of the federal programs.


### PR DESCRIPTION
Canadian Immigration system has changed amount of time needed to submit express entry application from 90 to 60 days.
https://www.canada.ca/en/immigration-refugees-citizenship/services/immigrate-canada/express-entry/submit-profile/rounds-invitations.html
